### PR TITLE
Fix panic

### DIFF
--- a/pkg/cleaner/aws/aws.go
+++ b/pkg/cleaner/aws/aws.go
@@ -75,7 +75,7 @@ func (a *Cleaner) cleanStacks() error {
 		}
 		a.logger.Log("level", "debug", "message", fmt.Sprintf("found that stack %#q should be deleted", *stack.StackName))
 
-		if *stack.EnableTerminationProtection {
+		if stack.EnableTerminationProtection != nil && *stack.EnableTerminationProtection {
 			enableTerminationProtection := false
 			updateTerminationProtection := &cloudformation.UpdateTerminationProtectionInput{
 				EnableTerminationProtection: &enableTerminationProtection,


### PR DESCRIPTION
ci-cleaner started failing with:
```
{"caller":"github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:76","level":"debug","message":"found that stack `cluster-ci-wip-66a35-c1c86-host-setup` should be deleted","time":"2018-08-23T13:01:49.144325+00:00"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x897044]

goroutine 1 [running]:
github.com/giantswarm/ci-cleaner/pkg/cleaner/aws.(*Cleaner).cleanStacks(0xc4201ec510, 0x30, 0xab20a0)
	/go/src/github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:78 +0x3f4
github.com/giantswarm/ci-cleaner/pkg/cleaner/aws.(*Cleaner).(github.com/giantswarm/ci-cleaner/pkg/cleaner/aws.cleanStacks)-fm(0xc4201e7c20, 0x89698c)
	/go/src/github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:50 +0x2a
github.com/giantswarm/ci-cleaner/pkg/cleaner/aws.(*Cleaner).Clean(0xc4201ec510, 0xc4201ec510, 0x0)
	/go/src/github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:55 +0x89
github.com/giantswarm/ci-cleaner/cmd.runAws(0x11405a0, 0xc420130660, 0x0, 0x6, 0x0, 0x0)
	/go/src/github.com/giantswarm/ci-cleaner/cmd/aws.go:58 +0x2e1
github.com/giantswarm/ci-cleaner/vendor/github.com/spf13/cobra.(*Command).execute(0x11405a0, 0xc4201305a0, 0x6, 0x6, 0x11405a0, 0xc4201305a0)
	/go/src/github.com/giantswarm/ci-cleaner/vendor/github.com/spf13/cobra/command.go:762 +0x468
github.com/giantswarm/ci-cleaner/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1140a60, 0x403e5c, 0xc420082058, 0x0)
	/go/src/github.com/giantswarm/ci-cleaner/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/giantswarm/ci-cleaner/vendor/github.com/spf13/cobra.(*Command).Execute(0x1140a60, 0x0, 0x922c71)
	/go/src/github.com/giantswarm/ci-cleaner/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.main()
	/go/src/github.com/giantswarm/ci-cleaner/main.go:10 +0x2d
Exited with code 2
```
See https://circleci.com/gh/giantswarm/ci-cleaner