### PR TITLE
fix azure resourcegroup cleaner

### DIFF
--- a/pkg/cleaner/azure/resourcegroup.go
+++ b/pkg/cleaner/azure/resourcegroup.go
@@ -73,7 +73,7 @@ func (c Cleaner) cleanResourceGroup(ctx context.Context) error {
 }
 
 func (c Cleaner) groupShouldBeDeleted(ctx context.Context, group resources.Group, since time.Time) (bool, error) {
-	if !isCIResource(*group.Name) || !isTerraformCIResourceGroup(*group.Name) {
+	if !isCIResource(*group.Name) && !isTerraformCIResourceGroup(*group.Name) {
 		return false, nil
 	}
 


### PR DESCRIPTION
Fix an issue where Azure resourcegroup cleaner was not correctly removing some resource groups.

I would happily provide test for this but `groupShouldBeDeleted` issue request to the Azure API, which I have no idea how to mock in tests. Any suggestion welcome here.