### PR TITLE
Let ci-cleaner build docker image, avoid building on cronjob execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
     - run:
         name: Install architect (except when in cronjob execution)
         command: |
-            if [ "${CIRCLE_USERNAME}" == "" ]; then
+            if [ "${CIRCLE_USERNAME}" != "" ]; then
                 wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
                 chmod +x ./architect
                 ./architect version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
     - deploy:
         name: architect deploy (master only, except when in cronjob execution)
         command: |
-            if [ -e "./architect" && "${CIRCLE_BRANCH}" == "master" ]; then
-                ./architect deploy
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                test -x ./architect && ./architect deploy
             fi
 
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
   cleanup:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "21 * * * *"
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     - deploy:
         name: architect deploy (master only, except when in cronjob execution)
         command: |
-            if [ test -x ./architect && "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ -x ./architect && "${CIRCLE_BRANCH}" == "master" ]; then
                 ./architect deploy
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     - deploy:
         name: architect deploy (master only, except when in cronjob execution)
         command: |
-            if [ -x ./architect && "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ -e "./architect" && "${CIRCLE_BRANCH}" == "master" ]; then
                 ./architect deploy
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,19 @@ cleanAWS: &cleanAWS
     steps:
     - checkout
 
-    - attach_workspace:
-        at: .
+    - run:
+        name: Set AWS credentials
+        command: ./scripts/aws_credentials.sh ${TYPE}
 
-    - run: ./scripts/aws_credentials.sh ${TYPE}
-
-    - run: ./ci-cleaner aws --access-key-id ${AWS_ACCESS_KEY_ID} --secret-access-key ${AWS_SECRET_ACCESS_KEY} --region ${AWS_DEFAULT_REGION}
-
+    - run:
+        name: Execute ci-cleaner for AWS
+        command: |
+            docker run --rm -ti \
+                quay.io/giantswarm/ci-cleaner:latest \
+                aws \
+                --access-key-id ${AWS_ACCESS_KEY_ID} \
+                --secret-access-key ${AWS_SECRET_ACCESS_KEY} \
+                --region ${AWS_DEFAULT_REGION}
 
 
 cleanAzure: &cleanAzure
@@ -17,11 +23,17 @@ cleanAzure: &cleanAzure
     steps:
     - checkout
 
-    - attach_workspace:
-        at: .
-
-    - run: ./ci-cleaner azure --client-id ${AZURE_CLIENT_ID} --client-secret ${AZURE_CLIENT_SECRET} --tenant-id ${AZURE_TENANT_ID} --subscription-id ${AZURE_SUBSCRIPTION_ID} --location ${AZURE_LOCATION}
-
+    - run:
+        name: Execute ci-cleaner for Azure
+        command: |
+            docker run --rm -ti \
+            quay.io/giantswarm/ci-cleaner:latest \
+            azure \
+            --subscription-id ${AZURE_SUBSCRIPTION_ID} \
+            --tenant-id ${AZURE_TENANT_ID} \
+            --client-id ${AZURE_CLIENT_ID} \
+            --client-secret ${AZURE_CLIENT_SECRET} \
+            --location ${AZURE_LOCATION}
 
 
 version: 2
@@ -31,20 +43,29 @@ jobs:
     steps:
     - checkout
 
-    - run: |
-        wget -q $(curl -sS https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-        chmod +x ./architect
-        ./architect version
+    - run:
+        name: Install architect (except when in cronjob execution)
+        command: |
+            if [ "${CIRCLE_USERNAME}" == "" ]; then
+                wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+                chmod +x ./architect
+                ./architect version
+            fi
 
-    - run: ./architect build
+    - run:
+        name: architect build (except when in cronjob execution)
+        command: test -x ./architect && ./architect build
+
+    - deploy:
+        name: architect deploy (master only, except when in cronjob execution)
+        command: |
+            if [ test -x ./architect && "${CIRCLE_BRANCH}" == "master" ]; then
+                ./architect deploy
+            fi
 
     - store_test_results:
         path: /tmp/results
 
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ./ci-cleaner
 
   cleanAWSHost:
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.8
+
+COPY ./ci-cleaner /ci-cleaner
+
+ENTRYPOINT ["/ci-cleaner"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/ci-cleaner/tree/master.svg?style=svg&circle-token=200804d99fdd5ee97482012f23d4470b62f8e34c)](https://circleci.com/gh/giantswarm/ci-cleaner/tree/master)
+[![Docker Repository on Quay](https://quay.io/repository/giantswarm/ci-cleaner/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/ci-cleaner)
 
 # CI Cleaner
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,4 +32,5 @@ func init() {
 
 	RootCmd.AddCommand(AwsCmd)
 	RootCmd.AddCommand(AzureCmd)
+	RootCmd.AddCommand(VersionCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// VersionCmd implements the 'version' command required by architect.
+	VersionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Does nothing.",
+		Run:   runVersionCmd,
+	}
+)
+
+func runVersionCmd(cmd *cobra.Command, args []string) {
+	fmt.Println("Not implemented.")
+}


### PR DESCRIPTION
ci-cleaner is running every hour as a cronjob. Currently it builds the ci-cleaner binary every time before execution.

To save CI resources, this PR lets us build a docker image on merge commits. This image is executed in cronjob runs.

To allow building using `architect`, this PR also adds a `ci-cleaner version` command, which architect expects to exist.