### PR TITLE
Prevent script from failing in cronjob context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,13 +54,13 @@ jobs:
 
     - run:
         name: architect build (except when in cronjob execution)
-        command: test -x ./architect && ./architect build
+        command: test -x ./architect && ./architect build || echo "Assuming we are in a cronjob. Not building."
 
     - deploy:
         name: architect deploy (master only, except when in cronjob execution)
         command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                test -x ./architect && ./architect deploy
+                test -x ./architect && ./architect deploy || echo "Assuming we are in a cronjob. Not deploying."
             fi
 
     - store_test_results:


### PR DESCRIPTION
In the last PR I forgot that in CircleCI, a command exiting with code != 0 means that the script stops and fails.