### PR TITLE
aws, azure: prepare for new test versions

### DIFF
--- a/pkg/cleaner/aws/aws.go
+++ b/pkg/cleaner/aws/aws.go
@@ -10,10 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/ci-cleaner/pkg/errorcollection"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-
-	"github.com/giantswarm/ci-cleaner/pkg/errorcollection"
 )
 
 type Config struct {
@@ -252,9 +251,10 @@ func bucketShouldBeDeleted(bucket *s3.Bucket) bool {
 	}
 
 	prefixes := []string{
+		"ci-last-",
+		"ci-prev-",
 		"ci-cur-",
 		"ci-wip-",
-		"ci-clop-",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(*bucket.Name, prefix) {

--- a/pkg/cleaner/azure/cleaner.go
+++ b/pkg/cleaner/azure/cleaner.go
@@ -119,7 +119,13 @@ func (c *Cleaner) Clean(ctx context.Context) error {
 }
 
 func isCIResource(s string) bool {
-	return strings.HasPrefix(s, "ci-cur-") || strings.HasPrefix(s, "ci-wip-")
+	r := false
+	r = r || strings.HasPrefix(s, "ci-last-")
+	r = r || strings.HasPrefix(s, "ci-prev-")
+	r = r || strings.HasPrefix(s, "ci-cur-")
+	r = r || strings.HasPrefix(s, "ci-wip-")
+
+	return r
 }
 
 func isAnyEmpty(list []string) bool {


### PR DESCRIPTION
They are introduced in e2esetup releaseindex package.
Names are "last" and "prev" replacing current "wip" and "cur"
respectively.