### PR TITLE
Don't error for 0 master instances

### DIFF
--- a/pkg/cleaner/aws/aws.go
+++ b/pkg/cleaner/aws/aws.go
@@ -370,7 +370,7 @@ func (a *Cleaner) disableMasterTerminationProtection(stackName string) error {
 		return microerror.Mask(err)
 	}
 
-	if len(o.Reservations) != 1 {
+	if len(o.Reservations) > 1 {
 		return microerror.Newf("Expected one reservation for master instance, got %d", len(o.Reservations))
 	}
 

--- a/pkg/cleaner/aws/aws.go
+++ b/pkg/cleaner/aws/aws.go
@@ -370,8 +370,9 @@ func (a *Cleaner) disableMasterTerminationProtection(stackName string) error {
 		return microerror.Mask(err)
 	}
 
-	if len(o.Reservations) > 1 {
-		return microerror.Newf("Expected one reservation for master instance, got %d", len(o.Reservations))
+	// If there are no masters we can stop here.
+	if len(o.Reservations) == 0 {
+		return nil
 	}
 
 	for _, reservation := range o.Reservations {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8141

Bot is failing when trying to disable the termination protection because there are 0 masters. We should continue in this case.

Also with HA masters coming soon it might make sense to drop the validation for there being 1 master?

```
{"caller":"github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:114","level":"info","message":"found that stack `cluster-ci-df8g3-guest-main` should be deleted","time":"2019-12-17T08:22:09.109234+00:00"}
{"caller":"github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:117","level":"debug","message":"disabling termination protection for EC2 instance belonging to the stack `cluster-ci-df8g3-guest-main`","time":"2019-12-17T08:22:09.109259+00:00"}
{"caller":"github.com/giantswarm/ci-cleaner/pkg/cleaner/aws/aws.go:122","level":"error","message":"failed disabling termination protection for EC2 instance belonging to the stack `cluster-ci-df8g3-guest-main`: \u0026errors.errorString{s:\"Expected one reservation for master instance, got 0\"}. Skipping deletion.","time":"2019-12-17T08:22:09.230331+00:00"}
```