### PR TITLE
Add regex for some unhandled CI resource names

### DIFF
--- a/pkg/cleaner/aws/aws.go
+++ b/pkg/cleaner/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -245,6 +246,7 @@ func stackShouldBeDeleted(stack *cloudformation.Stack) bool {
 		"cluster-ci-",
 		"host-peer-ci-",
 		"e2e-",
+		"ci-",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(*stack.StackName, prefix) {
@@ -280,24 +282,20 @@ func bucketShouldBeDeleted(bucket *s3.Bucket) bool {
 		return false
 	}
 
-	prefixes := []string{
-		"ci-last-",
-		"ci-prev-",
-		"ci-cur-",
-		"ci-wip-",
+	patterns := []string{
+		`\Aci-last-.*`,
+		`\Aci-prev-.*`,
+		`\Aci-cur-.*`,
+		`\Aci-wip-.*`,
+		`g8s-ci-cur-.*`,
+		`g8s-ci-wip-.*`,
+		`g8s-ci-clop-.*`,
+		`\Aci-.*-g8s-access-logs\z`,
+		`.*-g8s-ci-.*`,
 	}
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(*bucket.Name, prefix) {
-			return true
-		}
-	}
-	substrings := []string{
-		"g8s-ci-cur-",
-		"g8s-ci-wip-",
-		"g8s-ci-clop-",
-	}
-	for _, substring := range substrings {
-		if strings.Contains(*bucket.Name, substring) {
+	for _, pattern := range patterns {
+		matches, _ := regexp.MatchString(pattern, *bucket.Name)
+		if matches {
 			return true
 		}
 	}

--- a/pkg/cleaner/aws/aws_test.go
+++ b/pkg/cleaner/aws/aws_test.go
@@ -78,6 +78,24 @@ func TestStackShouldBeDeleted(t *testing.T) {
 			expected: true,
 		},
 		{
+			description: "recent aws ci stack should not be deleted",
+			stack: &cloudformation.Stack{
+				StackName:    aws.String("ci-aws-blabla123"),
+				CreationTime: aws.Time(time.Now()),
+				StackStatus:  aws.String("FOO_STATUS"),
+			},
+			expected: false,
+		},
+		{
+			description: "old aws ci stack should be deleted",
+			stack: &cloudformation.Stack{
+				StackName:    aws.String("ci-aws-blabla456"),
+				CreationTime: aws.Time(time.Now().Add(-2 * time.Hour)),
+				StackStatus:  aws.String("FOO_STATUS"),
+			},
+			expected: true,
+		},
+		{
 			description: "stack that is already being deleted",
 			stack: &cloudformation.Stack{
 				StackName:    aws.String("e2e-blabla"),
@@ -207,6 +225,38 @@ func TestBucketShouldBeDeleted(t *testing.T) {
 				CreationDate: aws.Time(time.Now().Add(-2 * time.Hour)),
 			},
 			expected: false,
+		},
+		{
+			description: "recent g8s log bucket should not be deleted",
+			bucket: &s3.Bucket{
+				Name:         aws.String("ci-blablabla-g8s-access-logs"),
+				CreationDate: aws.Time(time.Now()),
+			},
+			expected: false,
+		},
+		{
+			description: "old g8s log bucket should be deleted",
+			bucket: &s3.Bucket{
+				Name:         aws.String("ci-blablabla2345-g8s-access-logs"),
+				CreationDate: aws.Time(time.Now().Add(-2 * time.Hour)),
+			},
+			expected: true,
+		},
+		{
+			description: "recent g8s ci bucket should not be deleted",
+			bucket: &s3.Bucket{
+				Name:         aws.String("blablabla2345-g8s-ci-blabla678"),
+				CreationDate: aws.Time(time.Now()),
+			},
+			expected: false,
+		},
+		{
+			description: "old g8s ci bucket should be deleted",
+			bucket: &s3.Bucket{
+				Name:         aws.String("blablabla2345-g8s-ci-blabla678"),
+				CreationDate: aws.Time(time.Now().Add(-2 * time.Hour)),
+			},
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION
Replaces string prefixes and substrings with regex patterns, including new `aws-operator` test stack name and unhandled g8s CI bucket names.

Towards
https://github.com/giantswarm/giantswarm/issues/8141
https://github.com/giantswarm/giantswarm/issues/8452
https://github.com/giantswarm/giantswarm/issues/8263