### PR TITLE
Dns delegation clean azure

### DIFF
--- a/pkg/cleaner/azure/cleaner.go
+++ b/pkg/cleaner/azure/cleaner.go
@@ -103,6 +103,16 @@ func (c *Cleaner) Clean(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
+	err = c.cleanVPNConnection(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = c.cleanDNSRecordSet(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = c.cleanDelegateDNSRecords(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/cleaner/azure/cleaner.go
+++ b/pkg/cleaner/azure/cleaner.go
@@ -103,12 +103,7 @@ func (c *Cleaner) Clean(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	err = c.cleanVPNConnection(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = c.cleanDNSRecordSet(ctx)
+	err = c.cleanDelegateDNSRecords(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/cleaner/azure/cleaner.go
+++ b/pkg/cleaner/azure/cleaner.go
@@ -118,11 +118,6 @@ func (c *Cleaner) Clean(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	err = c.cleanDelegateDNSRecords(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	c.logger.LogCtx(ctx, "level", "debug", "message", "finished Azure CI cleanup")
 
 	return nil

--- a/pkg/cleaner/azure/delegatedns.go
+++ b/pkg/cleaner/azure/delegatedns.go
@@ -78,7 +78,7 @@ func (c Cleaner) dnsRecordShouldBeDeleted(ctx context.Context, dnsRecord dns.Rec
 
 	resolves, err := resolvesApiName(*dnsRecord.Name)
 	if err != nil {
-		c.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("Unexpected error when trying to resolve %s: %s", dnsRecord.Name, err.Error()))
+		c.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("Unexpected error when trying to resolve %s: %s", *dnsRecord.Name, err.Error()))
 		return false, nil
 	}
 
@@ -97,7 +97,6 @@ func resolvesApiName(name string) (bool, error) {
 	addresses, err := net.LookupHost(full)
 
 	if err != nil {
-		fmt.Printf(err.Error())
 		if !strings.Contains(err.Error(), dnsFailureError) {
 			return false, err
 		}

--- a/pkg/cleaner/azure/delegatedns.go
+++ b/pkg/cleaner/azure/delegatedns.go
@@ -43,6 +43,7 @@ func (c Cleaner) cleanDelegateDNSRecords(ctx context.Context) error {
 			c.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("DNS record %s has to be deleted", *record.Name))
 			err := c.deleteRecord(ctx, record)
 			if err != nil {
+				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to delete DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to check DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to delete DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 				c.logger.LogCtx(ctx, "level", "error", "message", "skipping")

--- a/pkg/cleaner/azure/delegatedns.go
+++ b/pkg/cleaner/azure/delegatedns.go
@@ -44,8 +44,6 @@ func (c Cleaner) cleanDelegateDNSRecords(ctx context.Context) error {
 			err := c.deleteRecord(ctx, record)
 			if err != nil {
 				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to delete DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
-				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to check DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
-				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to delete DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 				c.logger.LogCtx(ctx, "level", "error", "message", "skipping")
 				lastError = err
 				continue

--- a/pkg/cleaner/azure/delegatedns.go
+++ b/pkg/cleaner/azure/delegatedns.go
@@ -43,6 +43,7 @@ func (c Cleaner) cleanDelegateDNSRecords(ctx context.Context) error {
 			c.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("DNS record %s has to be deleted", *record.Name))
 			err := c.deleteRecord(ctx, record)
 			if err != nil {
+				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to check DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 				c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed to delete DNS record %q", *record.Name), "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 				c.logger.LogCtx(ctx, "level", "error", "message", "skipping")
 				lastError = err


### PR DESCRIPTION
Removed some log messages leftovers and fixed a log call because the circle CI build was complaining about it.